### PR TITLE
Added a check if curl redirect can work or not

### DIFF
--- a/classes/ZiggeoConnect.php
+++ b/classes/ZiggeoConnect.php
@@ -1,75 +1,83 @@
 <?php
 
 Class ZiggeoConnect {
-	
-	private $application;
-	
-	function __construct($application) {
-		$this->application = $application;
-	}
-	
-	private function curl($url) {
-		$curl = curl_init($this->application->config()->get("server_api_url") . "/v1" . $url); 
-		curl_setopt($curl, CURLOPT_FAILONERROR, true); 
-		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true); 
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true); 
-		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false); 
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_USERPWD, $this->application->token() . ":" . $this->application->private_key());
-		return $curl;
-	}
-	
-	private function assert_state($assert_states, $state, $result = array()) {
-		if (!is_array($assert_states))
-			$assert_states = array($assert_states);
-		foreach ($assert_states as $assert_state)
-			if ($assert_state == $state)
-				return;
-		throw new ZiggeoException($state, $result);
-	}
-	
-	function get($url, $data = array(), $assert_state = ZiggeoException::HTTP_STATUS_OK) {
-		if (count($data) > 0)
-			$url .= '?' . http_build_query($data);
-		$curl = $this->curl($url);
-		$result = curl_exec($curl);
-		$this->assert_state($assert_state, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
-		return $result; 
-	}
-	
-	function getJSON($url, $data = array(), $assert_state = ZiggeoException::HTTP_STATUS_OK) {
-		return json_decode($this->get($url, $data, $assert_state));
-	}
-	
-	function post($url, $data = array(), $assert_states = array(ZiggeoException::HTTP_STATUS_OK, ZiggeoException::HTTP_STATUS_CREATED)) {
-		$curl = $this->curl($url);
-		curl_setopt($curl, CURLOPT_POST, true);
-		foreach ($data as $key=>$value) {
-			if (is_array($value))
-				$data[$key] = json_encode($value);
-		}
-		if (@$data["file"] && class_exists("CurlFile"))
-			$data["file"] = new CurlFile(str_replace("@", "", $data["file"]), "video/mp4", "video.mp4");
-		curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-		$result = curl_exec($curl); 
-		$this->assert_state($assert_states, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
-		return $result; 
-	}
 
-	function postJSON($url, $data = array(), $assert_states = array(ZiggeoException::HTTP_STATUS_OK, ZiggeoException::HTTP_STATUS_CREATED)) {
-		return json_decode($this->post($url, $data, $assert_states));
-	}
+    private $application;
 
-	function delete($url, $assert_state = ZiggeoException::HTTP_STATUS_OK) {
-		$curl = $this->curl($url);
-		curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-		$result = curl_exec($curl); 
-		$this->assert_state($assert_state, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
-		return $result; 
-	}
+    function __construct($application) {
+        $this->application = $application;
+    }
 
-	function deleteJSON($url, $assert_state = ZiggeoException::HTTP_STATUS_OK) {
-		return json_decode($this->delete($url, $assert_state));
-	}
+    private function curl($url) {
+        $curl = curl_init($this->application->config()->get("server_api_url") . "/v1" . $url); 
+        curl_setopt($curl, CURLOPT_FAILONERROR, true);
+
+        if( (ini_get('safe_mode') === 'Off' || ini_get('safe_mode') === false) && ini_get('open_basedir') === '' ) {
+            //we can only make curl follow the redirects if the safe mod is off and open_basedir is not set, otherwise it would throw error
+            curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        }
+
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true); 
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false); 
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        curl_setopt($curl, CURLOPT_USERPWD, $this->application->token() . ":" . $this->application->private_key());
+
+        curl_exec($curl);
+
+        return $curl;
+    }
+
+    private function assert_state($assert_states, $state, $result = array()) {
+        if (!is_array($assert_states))
+            $assert_states = array($assert_states);
+        foreach ($assert_states as $assert_state)
+            if ($assert_state == $state)
+                return;
+        throw new ZiggeoException($state, $result);
+    }
+
+    function get($url, $data = array(), $assert_state = ZiggeoException::HTTP_STATUS_OK) {
+        if (count($data) > 0)
+            $url .= '?' . http_build_query($data);
+        $curl = $this->curl($url);
+        $result = curl_exec($curl);
+        $this->assert_state($assert_state, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
+        return $result; 
+    }
+
+    function getJSON($url, $data = array(), $assert_state = ZiggeoException::HTTP_STATUS_OK) {
+        return json_decode($this->get($url, $data, $assert_state));
+    }
+
+    function post($url, $data = array(), $assert_states = array(ZiggeoException::HTTP_STATUS_OK, ZiggeoException::HTTP_STATUS_CREATED)) {
+        $curl = $this->curl($url);
+        curl_setopt($curl, CURLOPT_POST, true);
+        foreach ($data as $key=>$value) {
+            if (is_array($value))
+                $data[$key] = json_encode($value);
+        }
+        if (@$data["file"] && class_exists("CurlFile"))
+            $data["file"] = new CurlFile(str_replace("@", "", $data["file"]), "video/mp4", "video.mp4");
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+        $result = curl_exec($curl); 
+        $this->assert_state($assert_states, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
+        return $result; 
+    }
+
+    function postJSON($url, $data = array(), $assert_states = array(ZiggeoException::HTTP_STATUS_OK, ZiggeoException::HTTP_STATUS_CREATED)) {
+        return json_decode($this->post($url, $data, $assert_states));
+    }
+
+    function delete($url, $assert_state = ZiggeoException::HTTP_STATUS_OK) {
+        $curl = $this->curl($url);
+        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+        $result = curl_exec($curl); 
+        $this->assert_state($assert_state, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
+        return $result; 
+    }
+
+    function deleteJSON($url, $assert_state = ZiggeoException::HTTP_STATUS_OK) {
+        return json_decode($this->delete($url, $assert_state));
+    }
 }


### PR DESCRIPTION
It shows as if a lot has been changed due to spaces.. I use space as tabs and the file had tabs which is likely why it shows it like that.

The only real difference is that there is now a check if the specific php features are present and if they are, it would not use redirect as one of the curl options.

https://github.com/Ziggeo/ZiggeoPhpSdk/compare/curl-open_basedir-fix?expand=1#diff-87a8a3a3617a5386ae379b5ed3e1397aR15

`if( (ini_get('safe_mode') === 'Off' || ini_get('safe_mode') === false) && ini_get('open_basedir') === '' ) {`

I checked what safe_mode should report back online and found that some had been checking with off and some with false, so I added both to be safe. :)