### PR TITLE
added resilience

### DIFF
--- a/classes/ZiggeoConfig.php
+++ b/classes/ZiggeoConfig.php
@@ -7,11 +7,13 @@ Class ZiggeoConfig {
 	
 	function __construct() {
 		$this->config = array(
-            "regions" => array("r1" => "https://srvapi-eu-west-1.ziggeo.com", ),
+			"regions" => array("r1" => "https://srvapi-eu-west-1.ziggeo.com", ),
 			"server_api_url" => "https://srvapi.ziggeo.com",
-            "api_regions" => array("r1" => "https://api-eu-west-1.ziggeo.com", ),
-            "api_url" => "https://api-us-east-1.ziggeo.com",
-            "request_timeout" => 60,
+			"api_regions" => array("r1" => "https://api-eu-west-1.ziggeo.com", ),
+			"api_url" => "https://api-us-east-1.ziggeo.com",
+			"request_timeout" => 60,
+			"resilience_factor" => 5,
+            "resilience_onfail" => [ "error" => true ] //change this to represent code that returns if your server does not reach our server for some reason even after few attempts. Can be any valid code that your code can look out for.
 		);
 	}
 	
@@ -19,9 +21,9 @@ Class ZiggeoConfig {
 		return $this->config[$ident];
 	}
 
-    function set($ident, $value) {
-        $this->config[$ident] = $value;
-        return $this;
-    }
+	function set($ident, $value) {
+		$this->config[$ident] = $value;
+		return $this;
+	}
 	
 }

--- a/classes/ZiggeoConnect.php
+++ b/classes/ZiggeoConnect.php
@@ -3,11 +3,14 @@
 Class ZiggeoConnect {
 
     private $application;
+    private $config;
 
     function __construct($application, $baseUrl, $requestTimeout) {
         $this->application = $application;
         $this->baseUrl = $baseUrl;
         $this->requestTimeout = $requestTimeout;
+
+        $this->config = new ZiggeoConfig($this);
     }
 
     private function curl($url) {
@@ -30,6 +33,90 @@ Class ZiggeoConnect {
         return $curl;
     }
 
+    private function singleRequest($request_type = 'POST', $url = '', $data) {
+
+        $curl = $this->curl($url);
+
+        //If the request type is POST we set up additional parameters as we need to handle data differently
+        if($request_type === 'POST') {
+            curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+        }
+        elseif($request_type === 'DELETE') {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+        }
+
+        //Let us make the call
+        $result_data = curl_exec($curl);
+
+        //At this time both are supported, since later is legacy now soon it will be dropped, so future proofing
+        if(version_compare('5.5.0', PHP_VERSION, '>=') && version_compare( '7.10.8', curl_version(['version']), '>=')) {
+            $response_const = CURLINFO_RESPONSE_CODE;
+        }
+        else {
+            $response_const = CURLINFO_HTTP_CODE;
+        }
+
+        //Let us get the info on the call
+        $result_info = [
+            //get the last response code
+            'response_code' => curl_getinfo($curl, $response_const),
+            //The CONNECT response code 
+            'connect_code' => curl_getinfo($curl, CURLINFO_HTTP_CONNECTCODE),
+            //Errno from a connect failure. The number is OS and system specific. 
+            'os_code' => curl_getinfo($curl, CURLINFO_OS_ERRNO)
+        ];
+
+        //Lets prep the data
+        $rez = [
+            'response'  => $result_data,
+            'info'      => $result_info,
+            'error'     => false
+        ];
+
+        //Did an error occur?
+        if(curl_errno($curl)) {
+            //error occurred 
+            $rez['error'] = [
+                'error_number'  => curl_errno($curl),
+                'error_message' => curl_error($curl)
+            ];
+        }
+
+        // Close handle
+        // curl_close($curl);
+
+        return $rez;
+    }
+
+    public function makeRequest($request_type = 'POST', $url, $data = false) {
+
+        $success = false;
+
+        for($i = 0; $i < $this->config->get("resilience_factor"); $i++) {
+
+            $result = $this->singleRequest($request_type, $url, $data);
+
+            //Lets check if it is expected response - above 200 and under 500
+            if( isset($result['info']) &&
+                (int)$result['info']['response_code'] >= 200 && (int)$result['info']['response_code'] < 500) {
+
+                //good to go
+                return $result;
+            }
+
+        }
+
+        //If failed return the default value
+        $result['response'] = $this->config->get("resilience_onfail");
+
+        if($result['info']['response_code'] === 0) {
+            $result['info']['response_code'] = 900; //Just a unique code to recognize that the error is internal in nature. At this point you could grab more details from $result['error']
+        }
+
+        return $result;
+    }
+
     private function assert_state($assert_states, $state, $result = array()) {
         if (!is_array($assert_states))
             $assert_states = array($assert_states);
@@ -40,12 +127,15 @@ Class ZiggeoConnect {
     }
 
     function get($url, $data = array(), $assert_state = ZiggeoException::HTTP_STATUS_OK) {
-        if (count($data) > 0)
+        if (count($data) > 0) {
             $url .= '?' . http_build_query($data);
-        $curl = $this->curl($url);
-        $result = curl_exec($curl);
-        $this->assert_state($assert_state, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
-        return $result; 
+        }
+
+        $result = $this->makeRequest('GET', $url);
+
+        $this->assert_state($assert_state, $result['info']['response_code'], $result['response']);
+
+        return $result['response'];
     }
 
     function getJSON($url, $data = array(), $assert_state = ZiggeoException::HTTP_STATUS_OK) {
@@ -53,18 +143,20 @@ Class ZiggeoConnect {
     }
 
     function post($url, $data = array(), $assert_states = array(ZiggeoException::HTTP_STATUS_OK, ZiggeoException::HTTP_STATUS_CREATED)) {
-        $curl = $this->curl($url);
-        curl_setopt($curl, CURLOPT_POST, true);
+
         foreach ($data as $key=>$value) {
             if (is_array($value))
                 $data[$key] = json_encode($value);
         }
-        if (@$data["file"] && class_exists("CurlFile"))
+
+        if (isset($data["file"]) && class_exists("CurlFile")) {
             $data["file"] = new CurlFile(str_replace("@", "", $data["file"]), "video/mp4", "video.mp4");
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-        $result = curl_exec($curl); 
-        $this->assert_state($assert_states, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
-        return $result; 
+        }
+
+        $result = $this->makeRequest('POST', $url, $data);
+
+        $this->assert_state($assert_states, $result['info']['response_code'], $result['response']);
+        return $result['response'];
     }
 
     function postJSON($url, $data = array(), $assert_states = array(ZiggeoException::HTTP_STATUS_OK, ZiggeoException::HTTP_STATUS_CREATED)) {
@@ -72,11 +164,11 @@ Class ZiggeoConnect {
     }
 
     function delete($url, $assert_state = ZiggeoException::HTTP_STATUS_OK) {
-        $curl = $this->curl($url);
-        curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-        $result = curl_exec($curl); 
-        $this->assert_state($assert_state, curl_getinfo($curl, CURLINFO_HTTP_CODE), $result);
-        return $result; 
+
+        $result = $this->makeRequest('DELETE', $url);
+
+        $this->assert_state($assert_state, $result['info']['response_code'], $result['response']);
+        return $result['response'];
     }
 
     function deleteJSON($url, $assert_state = ZiggeoException::HTTP_STATUS_OK) {


### PR DESCRIPTION
* Next to expected (5 times re-try, accept 200>x<500 response I also added 900 as a response code when no response code exists like when DNS resolution fails and such as the response code in those cases is 0. This way it makes it slightly easier to identify what might have happened.

There is also an error info collected that with slight tweak of code would allow one to easily get the details why something happened.